### PR TITLE
Add a ynab_use_markdown switch (default to true) to linkify automatically

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -4,3 +4,4 @@ ynab_api_key=
 ynab_budget_id=
 ynab_payee_name_to_be_processed=
 ynab_payee_name_processing_completed=
+ynab_use_markdown=false

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A program to annotate YNAB transactions with Amazon order info
         AMAZON_PASSWORD=your-amazon-password
         ```
 6. **Install Dependencies**:
+   - Install `uv` ([instructions](https://github.com/astral-sh/uv?tab=readme-ov-file#installation)) if needed
    - Run the following command to install the required dependencies:
      ```bash
      uv sync

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def process_transactions() -> None:
         elif len(amazon_tran.item_names) == 1:
             memo += amazon_tran.item_names[0] + "  \n"
 
-        memo += formatted_link("Link", amazon_tran.order_link)
+        memo += _formatted_link("Link", amazon_tran.order_link)
 
         print('\nMemo:')
         print(memo)
@@ -46,10 +46,19 @@ def process_transactions() -> None:
             ynab_transactions.update_ynab_transaction(transaction=ynab_tran, memo=memo, payee_id=amazon_with_memo_payee.id)
             print('\n\n')
 
-def formatted_link(
+def _formatted_link(
     title: str,
     url: str
 ) -> str:
+    """Returns a link in markdown or raw format, dependent on ynab_use_markdown
+
+    Args:
+        title (str): The name for the link
+        url (str): The URL to link to
+
+    Returns:
+        str: A URL string suitable for injection into the memo
+    """
 
     if settings.ynab_use_markdown:
         return f"[{title}]({url})"

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import ynab_transactions
 from typing import List
 from amazon_transactions import TransactionWithOrderInfo
 
+from settings import settings
 
 def process_transactions() -> None:
     ynab_trans, amazon_with_memo_payee = ynab_transactions.get_ynab_transactions()
@@ -32,8 +33,8 @@ def process_transactions() -> None:
         elif len(amazon_tran.item_names) == 1:
             memo += amazon_tran.item_names[0] + "  \n"
 
-        memo += amazon_tran.order_link
-            
+        memo += formatted_link("Link", amazon_tran.order_link)
+
         print('\nMemo:')
         print(memo)
 
@@ -44,6 +45,16 @@ def process_transactions() -> None:
             print('updating...')
             ynab_transactions.update_ynab_transaction(transaction=ynab_tran, memo=memo, payee_id=amazon_with_memo_payee.id)
             print('\n\n')
+
+def formatted_link(
+    title: str,
+    url: str
+) -> str:
+
+    if settings.ynab_use_markdown:
+        return f"[{title}]({url})"
+
+    return url
 
 def find_matching_amazon_transaction(amazon_trans, amount) -> TransactionWithOrderInfo | None:
     amount = amount * -1

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def process_transactions() -> None:
         elif len(amazon_tran.item_names) == 1:
             memo += amazon_tran.item_names[0] + "  \n"
 
-        memo += _formatted_link("Link", amazon_tran.order_link)
+        memo += _formatted_link(f"Order #{amazon_tran.order_number}", amazon_tran.order_link)
 
         print('\nMemo:')
         print(memo)

--- a/settings.py
+++ b/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
 
     ynab_payee_name_to_be_processed: str = "Amazon - Needs Memo"
     ynab_payee_name_processing_completed: str = "Amazon"
+    ynab_use_markdown: bool = False
 
 
 settings = Settings()  # type: ignore[call-arg]


### PR DESCRIPTION
Add the option to use markdown in the memo.

I tested out the original program and found that it inserted a link (yes!), but it wasn't available to click.  I didn't even know this was possible with YNAB Toolkit except for the README, so thanks for that!

One behavior I'm not sure how to work around... after editing a multiline memo on the UI, it reverts to single line.  I know that's not in this tool's job description, but curious if there's any advice.  (Mac Sequoia 15.4, Firefox 137.0, YNAB Toolkit 3.16.0).