### PR TITLE
Fix all ruff warnings and errors - uv run ruff check passes

### DIFF
--- a/amazon_transactions.py
+++ b/amazon_transactions.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from datetime import date
-from typing import List
 
 from amazonorders.entity.order import Order
 from amazonorders.entity.transaction import Transaction
@@ -11,46 +10,80 @@ from amazonorders.transactions import AmazonTransactions
 # import config
 from settings import settings
 
-TransactionWithOrderInfo = namedtuple("TransactionWithOrderInfo", ['completed_date', 'transaction_total', 'order_total', 'order_number', 'order_link', 'item_names'])
+TransactionWithOrderInfo = namedtuple(
+    "TransactionWithOrderInfo",
+    [
+        "completed_date",
+        "transaction_total",
+        "order_total",
+        "order_number",
+        "order_link",
+        "item_names",
+    ],
+)
 
 
-def get_amazon_transactions() -> List[TransactionWithOrderInfo]:
-    amazon_session = AmazonSession(username=settings.amazon_user, password=settings.amazon_password.get_secret_value())
+def get_amazon_transactions() -> list[TransactionWithOrderInfo]:
+    """Returns a list of transactions with order info.
+
+    Returns:
+        list[TransactionWithOrderInfo]: A list of transactions with order info
+    """
+    amazon_session = AmazonSession(
+        username=settings.amazon_user,
+        password=settings.amazon_password.get_secret_value(),
+    )
     amazon_session.login()
 
     amazon_orders = AmazonOrders(amazon_session)
-    orders: List[Order] = amazon_orders.get_order_history(
+    orders: list[Order] = amazon_orders.get_order_history(
         year=str(date.today().year)
     )  # TODO - fetch previous year as well (and merge) if the current date is within the first month of this year
     orders.sort(key=lambda order: order.order_placed_date)
     orders_dict: dict[str, Order] = {order.order_number: order for order in orders}
 
-    amazon_transactions: List[Transaction] = AmazonTransactions(amazon_session=amazon_session).get_transactions(days=31)
+    amazon_transactions: list[Transaction] = AmazonTransactions(
+        amazon_session=amazon_session
+    ).get_transactions(days=31)
     amazon_transactions.sort(key=lambda trans: trans.completed_date)
 
     amazon_transaction_with_order_details: list[TransactionWithOrderInfo] = []
     for transaction in amazon_transactions:
         if not (order := orders_dict.get(transaction.order_number)):
             continue
-        amazon_transaction_with_order_details.append(TransactionWithOrderInfo(completed_date=transaction.completed_date, transaction_total=int(transaction.grand_total * -1000), order_total=int(order.grand_total * 1000),  order_number=transaction.order_number, order_link=transaction.order_details_link,  item_names=[item.title for item in order.items]))
+        amazon_transaction_with_order_details.append(
+            TransactionWithOrderInfo(
+                completed_date=transaction.completed_date,
+                transaction_total=int(transaction.grand_total * -1000),
+                order_total=int(order.grand_total * 1000),
+                order_number=transaction.order_number,
+                order_link=transaction.order_details_link,
+                item_names=[item.title for item in order.items],
+            )
+        )
 
     return amazon_transaction_with_order_details
 
-def print_amazon_transactions(amazon_transaction_with_order_details):
 
+def print_amazon_transactions(amazon_transaction_with_order_details: list[TransactionWithOrderInfo]):
+    """Prints a list of transactions to the screen for inspection.
+
+    Args:
+        amazon_transaction_with_order_details (list[TransactionWithOrderInfo]): a list of transactions to print
+    """
     for transaction in amazon_transaction_with_order_details:
         info = transaction._asdict()
         for label, value in info.items():
             if isinstance(value, list):
-                print(f'{label}:')
+                print(f"{label}:")
                 for i, item in enumerate(value, start=1):
-                    print(f'    {i}: {item}')
+                    print(f"    {i}: {item}")
             elif isinstance(value, int):
-                print(f"{label}: ${value/1000:.2f}")
+                print(f"{label}: ${value / 1000:.2f}")
             else:
-                print(f'{label}: {value}')
+                print(f"{label}: {value}")
         print()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print_amazon_transactions(get_amazon_transactions())

--- a/main.py
+++ b/main.py
@@ -1,31 +1,37 @@
 import amazon_transactions
 import ynab_transactions
-from typing import List
 from amazon_transactions import TransactionWithOrderInfo
 
 
 def process_transactions() -> None:
+    """Match YNAB transactions to Amazon Transactions and optionally update YNAB Memos."""
     ynab_trans, amazon_with_memo_payee = ynab_transactions.get_ynab_transactions()
-    print('please wait... (amazon transactions are being fetched, which takes a while)')
-    amazon_trans: List[TransactionWithOrderInfo] = amazon_transactions.get_amazon_transactions()
+    print("please wait... (amazon transactions are being fetched, which takes a while)")
+    amazon_trans: list[TransactionWithOrderInfo] = (
+        amazon_transactions.get_amazon_transactions()
+    )
     if not ynab_trans:
-        print('No matching Transactions found in YNAB. Exiting.')
+        print("No matching Transactions found in YNAB. Exiting.")
         return
-    print('\n\n\nStarting to look for matching transactions...\n')
+    print("\n\n\nStarting to look for matching transactions...\n")
     for ynab_tran in ynab_trans:
         print(
-            f"\n\nLooking for an Amazon Transaction that matches this YNAB transaction: {ynab_tran.var_date} ${ynab_tran.amount/-1000:.2f}"
+            f"\n\nLooking for an Amazon Transaction that matches this YNAB transaction: {ynab_tran.var_date} ${ynab_tran.amount / -1000:.2f}"
         )
-        amazon_tran: TransactionWithOrderInfo | None = find_matching_amazon_transaction(amazon_trans=amazon_trans, amount=ynab_tran.amount)
+        amazon_tran: TransactionWithOrderInfo | None = find_matching_amazon_transaction(
+            amazon_trans=amazon_trans, amount=ynab_tran.amount
+        )
         if not amazon_tran:
-            print(f"**** Could not find a matching Amazon Transaction!")
+            print("**** Could not find a matching Amazon Transaction!")
             continue
-        print(f"Found a matching Amazon Transaction!")
-        print(f"Matching Amazon Transaction: {amazon_tran.completed_date} ${amazon_tran.transaction_total/1000:.2f}")
+        print("Found a matching Amazon Transaction!")
+        print(
+            f"Matching Amazon Transaction: {amazon_tran.completed_date} ${amazon_tran.transaction_total / 1000:.2f}"
+        )
 
         memo: str = ""
         if amazon_tran.transaction_total != amazon_tran.order_total:
-            memo += f"-This transaction doesn't represent the entire order. The order total is ${amazon_tran.order_total/1000:.2f}-    \n\n"
+            memo += f"-This transaction doesn't represent the entire order. The order total is ${amazon_tran.order_total / 1000:.2f}-    \n\n"
         if len(amazon_tran.item_names) > 1:
             for i, item in enumerate(amazon_tran.item_names, start=1):
                 memo += f"{i}. {item}  \n"
@@ -33,23 +39,41 @@ def process_transactions() -> None:
             memo += amazon_tran.item_names[0] + "  \n"
 
         memo += amazon_tran.order_link
-            
-        print('\nMemo:')
+
+        print("\nMemo:")
         print(memo)
 
-        no: str = input('\nupdate transaction? press enter to continue, type anything and press enter to skip...')
+        no: str = input(
+            "\nupdate transaction? press enter to continue, type anything and press enter to skip..."
+        )
         if no:
-            print('skipping...\n\n')
+            print("skipping...\n\n")
         else:
-            print('updating...')
-            ynab_transactions.update_ynab_transaction(transaction=ynab_tran, memo=memo, payee_id=amazon_with_memo_payee.id)
-            print('\n\n')
+            print("updating...")
+            ynab_transactions.update_ynab_transaction(
+                transaction=ynab_tran, memo=memo, payee_id=amazon_with_memo_payee.id
+            )
+            print("\n\n")
 
-def find_matching_amazon_transaction(amazon_trans, amount) -> TransactionWithOrderInfo | None:
+
+def find_matching_amazon_transaction(
+    amazon_trans: list[TransactionWithOrderInfo],
+    amount: int
+) -> TransactionWithOrderInfo | None:
+    """Given an amount, locate a matching Amazon transaction.
+
+    Args:
+        amazon_trans (list[TransactionWithOrderInfo]): A list of Amazon transactions
+        amount (int): An amount to match
+
+    Returns:
+        TransactionWithOrderInfo | None: A matched transaction or None if no match
+    """
     amount = amount * -1
     for a_tran in amazon_trans:
         if a_tran.transaction_total == amount:
             return a_tran
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     process_transactions()

--- a/ynab_transactions.py
+++ b/ynab_transactions.py
@@ -100,7 +100,7 @@ def get_ynab_transactions(
     )
     if not (amazon_needs_memo_payee and amazon_with_memo_payee):
         rprint("[bold red]Unable to find payees, exiting.[/]")
-        return None, None # returning tuple of None values to maintain type consistency
+        return None, None  # returning tuple of None values to maintain type consistency
 
     ynab_transactions = get_transactions_by_payee(
         budget_id=budget_id, payee=amazon_needs_memo_payee


### PR DESCRIPTION
Make sure that `ruff check` passes!  Most changes outside of the docstrings and adding types were accomplished with `ruff check --fix`