### PR TITLE
Fix YNAB Transaction Memo Character Limit

### DIFF
--- a/src/ynamazon/main.py
+++ b/src/ynamazon/main.py
@@ -38,6 +38,68 @@ class MultiLineText(BaseModel):
         self.lines.append(line)
 
 
+def truncate_memo(memo: str) -> str:
+    """Ensure memo doesn't exceed YNAB's character limit by truncating each line proportionally.
+    
+    Args:
+        memo (str): The full memo text
+        
+    Returns:
+        str: Truncated memo with each line shortened proportionally if needed
+    """
+    max_length = 500  # YNAB's character limit
+    
+    # Keep this check for function's integrity as a standalone utility
+    if len(memo) <= max_length:
+        return memo
+    
+    # Split the memo into lines
+    lines = memo.split('\n')
+    
+    # Calculate how many characters need to be removed
+    excess_chars = len(memo) - max_length
+    
+    # Count total characters in item lines (excluding warning and URL lines)
+    item_lines = []
+    non_item_lines = []
+    
+    for line in lines:
+        # Identify item lines (numbered items)
+        if line.strip() and (line.strip()[0].isdigit() and '. ' in line):
+            item_lines.append(line)
+        else:
+            non_item_lines.append(line)
+    
+    # If no item lines found, fall back to simple truncation
+    if not item_lines:
+        return memo[:max_length - 12] + " [truncated]"
+    
+    # Calculate characters to remove from each item line
+    chars_per_line = excess_chars // len(item_lines)
+    
+    # Truncate each item line
+    new_lines = []
+    for line in lines:
+        if line in item_lines:
+            # For numbered items, preserve the numbering, truncate the content
+            parts = line.split('. ', 1)
+            if len(parts) == 2 and len(parts[1]) > chars_per_line + 3:
+                truncated_item = parts[0] + '. ' + parts[1][:-(chars_per_line + 3)] + '...'
+                new_lines.append(truncated_item)
+            else:
+                new_lines.append(line)  # Line too short to truncate
+        else:
+            new_lines.append(line)  # Don't truncate non-item lines
+    
+    result = '\n'.join(new_lines)
+    
+    # Final check - if we're still over the limit, do a simple truncation
+    if len(result) > max_length:
+        return result[:max_length - 12] + " [truncated]"
+    
+    return result
+
+
 # TODO: reduce complexity of this function
 def process_transactions(  # noqa: C901
     amazon_config: AmazonConfig | None = None,
@@ -108,6 +170,15 @@ def process_transactions(  # noqa: C901
         console.print("[bold u green]Memo:[/]")
         console.print(str(memo))
 
+        # Check if memo needs truncation and display before/after if needed
+        if len(str(memo)) > 500:
+            console.print(f"[yellow]Warning: Memo exceeds YNAB's 500 character limit ({len(str(memo))} characters)[/]")
+            original_memo = str(memo)
+            memo = truncate_memo(original_memo)
+            console.print("[bold cyan]Memo after truncation:[/]")
+            console.print(memo)
+            console.print(f"[green]Truncated from {len(original_memo)} to {len(memo)} characters[/]")
+
         if amazon_tran.completed_date != ynab_tran.var_date:
             console.print(
                 f"[yellow]**** The dates don't match! YNAB: {ynab_tran.var_date} Amazon: {amazon_tran.completed_date}[/]"
@@ -136,7 +207,7 @@ def process_transactions(  # noqa: C901
 
         update_ynab_transaction(
             transaction=ynab_tran,
-            memo=str(memo),
+            memo=memo,
             payee_id=amazon_with_memo_payee.id,
         )
         console.print("\n\n")

--- a/src/ynamazon/ynab_transactions.py
+++ b/src/ynamazon/ynab_transactions.py
@@ -163,32 +163,6 @@ def update_ynab_transaction(
     data = PutTransactionWrapper(
         transaction=ExistingTransaction.model_validate(transaction.to_dict())
     )
-    
-    # Ensure memo doesn't exceed 500 character limit
-    if len(memo) > 500:
-        logger.warning(f"Memo exceeds 500 character limit ({len(memo)} chars). Truncating...")
-        # Keep the important parts - first warning line, and the URL at the end
-        lines = memo.split('\n')
-        
-        # Extract the URL at the end (it must be preserved)
-        url_line = lines[-1]
-        
-        # Keep the warning header if it exists
-        header = ""
-        if len(lines) > 0 and '-This transaction doesn' in lines[0]:
-            header = lines[0] + '\n\n'
-        
-        # Calculate remaining space for content
-        remaining_space = 500 - len(header) - len(url_line) - 4  # 4 chars for "...\n"
-        
-        # Get middle content (item list) and truncate if needed
-        middle_content = '\n'.join(lines[1:-1])
-        if len(middle_content) > remaining_space:
-            middle_content = middle_content[:remaining_space] + "..."
-        
-        # Combine the parts to stay under 500 chars
-        memo = f"{header}{middle_content}\n{url_line}"
-    
     data.transaction.memo = memo
     data.transaction.payee_id = payee_id
     with ApiClient(configuration=configuration) as api_client:

--- a/src/ynamazon/ynab_transactions.py
+++ b/src/ynamazon/ynab_transactions.py
@@ -163,6 +163,32 @@ def update_ynab_transaction(
     data = PutTransactionWrapper(
         transaction=ExistingTransaction.model_validate(transaction.to_dict())
     )
+    
+    # Ensure memo doesn't exceed 500 character limit
+    if len(memo) > 500:
+        logger.warning(f"Memo exceeds 500 character limit ({len(memo)} chars). Truncating...")
+        # Keep the important parts - first warning line, and the URL at the end
+        lines = memo.split('\n')
+        
+        # Extract the URL at the end (it must be preserved)
+        url_line = lines[-1]
+        
+        # Keep the warning header if it exists
+        header = ""
+        if len(lines) > 0 and '-This transaction doesn' in lines[0]:
+            header = lines[0] + '\n\n'
+        
+        # Calculate remaining space for content
+        remaining_space = 500 - len(header) - len(url_line) - 4  # 4 chars for "...\n"
+        
+        # Get middle content (item list) and truncate if needed
+        middle_content = '\n'.join(lines[1:-1])
+        if len(middle_content) > remaining_space:
+            middle_content = middle_content[:remaining_space] + "..."
+        
+        # Combine the parts to stay under 500 chars
+        memo = f"{header}{middle_content}\n{url_line}"
+    
     data.transaction.memo = memo
     data.transaction.payee_id = payee_id
     with ApiClient(configuration=configuration) as api_client:


### PR DESCRIPTION
# Fix YNAB Transaction Memo Character Limit

## Description
This PR addresses an error that occurs when updating YNAB transactions with Amazon order details that exceed YNAB's 500-character memo limit. The solution implements smart memo truncation that preserves critical information while staying within the character limit.

## Changes
- Add mechanism to detect when memos exceed the 500-character limit
- Implement intelligent truncation that preserves:
  - The Amazon order URL (critical for accessing order details)
  - Warning about partial orders (if present)
  - As many complete item descriptions as possible
- Add logging to notify when truncation occurs

## Testing
Tested with various Amazon transactions, including large orders with multiple items and products with long descriptions.

## Why This Approach
This approach ensures users can always access the complete order details through the preserved Amazon URL link, while maintaining a clean memo format without any unnecessary indicators. The truncation logic is clean and prioritizes the most important information.

Fixes issue: #11 