### PR TITLE
Cache Amazon Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ config.py
 output
 .DS_Store
 
+# cache of amazon or ynab
+cache/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/amazon_transactions.py
+++ b/amazon_transactions.py
@@ -8,6 +8,10 @@ from amazonorders.session import AmazonSession
 from amazonorders.transactions import AmazonTransactions
 
 from cache_decorator import Cache
+import os
+from os import path
+from os.path import join
+import tempfile
 
 from cli_parser import CLIParser
 
@@ -46,7 +50,7 @@ def get_amazon_transactions(use_cache: bool = True) -> list[TransactionWithOrder
 @Cache(
   validity_duration="10m",
   enable_cache_arg_name="use_cache",
-  cache_path="cache/amazon_transactions_json_compatible_amazon_transactions/{_hash}.json"
+  cache_path=os.path.join(tempfile.gettempdir(), "ynamazon", "amazon_transactions_json_compatible_amazon_transactions_{_hash}.json")
 )
 def _json_compatible_amazon_transactions() -> list[TransactionWithOrderInfo]:
     amazon_session = AmazonSession(

--- a/amazon_transactions.py
+++ b/amazon_transactions.py
@@ -9,8 +9,6 @@ from amazonorders.transactions import AmazonTransactions
 
 from cache_decorator import Cache
 import os
-from os import path
-from os.path import join
 import tempfile
 
 from cli_parser import CLIParser

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -1,0 +1,20 @@
+import argparse
+
+class CLIParser:
+    def __init__(self):
+        self.args = self._parse_args()
+
+    def __getattr__(self, name):
+        # import pdb; pdb.set_trace();
+        return getattr(self.args, name)
+
+    def _parse_args(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--force-refresh-amazon',
+            help="Refreshes transactions directly from Amazon instead of using a recently cached version",
+            default=False,
+            type=bool,
+            action=argparse.BooleanOptionalAction
+        )
+        return parser.parse_args()

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -1,26 +1,30 @@
 import argparse
 
 class CLIParser:
+    """Parses cli arguments using argparse, making them available outside. This class is a Singleton (only one instance)."""
     _instance = None
 
     def __new__(cls, *_args, **_kwargs):
-        if cls._instance == None:
+        """This method implements the Singleton logic."""
+        if cls._instance is None:
             cls._instance = super().__new__(cls, *_args, **_kwargs)
 
         return cls._instance
 
     def __init__(self):
-        self.args = self._parse_args()
+        """Initialize by parsing the args."""
+        self._args = self._parse_args()
 
     def __getattr__(self, name):
-        # import pdb; pdb.set_trace();
-        return getattr(self.args, name)
+        """This method passes through methods directly to the underlying args that were argparsed."""
+        return getattr(self._args, name)
 
     def _parse_args(self):
+        """This method parses using argparse."""
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '--force-refresh-amazon',
-            help="Refreshes transactions directly from Amazon instead of using a recently cached version",
+            help="Refreshes transactions directly from Amazon instead of using a recently cached version.",
             default=False,
             type=bool,
             action=argparse.BooleanOptionalAction

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -1,6 +1,14 @@
 import argparse
 
 class CLIParser:
+    _instance = None
+
+    def __new__(cls, *_args, **_kwargs):
+        if cls._instance == None:
+            cls._instance = super().__new__(cls, *_args, **_kwargs)
+
+        return cls._instance
+
     def __init__(self):
         self.args = self._parse_args()
 

--- a/main.py
+++ b/main.py
@@ -4,12 +4,21 @@ from amazon_transactions import TransactionWithOrderInfo
 
 from settings import settings
 
+from cli_parser import CLIParser
+
 def process_transactions() -> None:
     """Match YNAB transactions to Amazon Transactions and optionally update YNAB Memos."""
     ynab_trans, amazon_with_memo_payee = ynab_transactions.get_ynab_transactions()
-    print("please wait... (amazon transactions are being fetched, which takes a while)")
+
+    use_amazon_cache = not CLIParser().force_refresh_amazon
+
+    if use_amazon_cache:
+      print("Amazon transactions may need to be refreshed. If so, please wait as it can take a while...")
+    else:
+      print("Forcing refresh of Amazon transactions. Please wait as it can take a while...")
+
     amazon_trans: list[TransactionWithOrderInfo] = (
-        amazon_transactions.get_amazon_transactions()
+        amazon_transactions.get_amazon_transactions(use_cache = use_amazon_cache)
     )
     if not ynab_trans:
         print("No matching Transactions found in YNAB. Exiting.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.8.1",
     "rich>=14.0.0",
     "ynab>=1.3.1",
+    "cache-decorator>=2.2.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cache-decorator"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "compress-json" },
+    { name = "compress-pickle" },
+    { name = "deflate-dict" },
+    { name = "dict-hash" },
+    { name = "humanize" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/52/b372ebef6d7e8322dd46ff176fa91cb8374adee85ec54fd6b13bbe0a8eaf/cache_decorator-2.2.0.tar.gz", hash = "sha256:ebb427b5acb00fb0a47ed9fc7d52fe96de94f40ca52f381205ace8756df6df5a", size = 35875 }
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +168,27 @@ wheels = [
 ]
 
 [[package]]
+name = "compress-json"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/e5/3974ae0348691434795902f587e33b2e0cb10fdd66a649ca32edabcc4fcb/compress_json-1.1.1.tar.gz", hash = "sha256:2d9aea3fabfe3b9a77d2a8afa005c47a6b3b3fb59d6eb833ec3337f99fba3164", size = 6629 }
+
+[[package]]
+name = "compress-pickle"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/23/a448abd4e98b64ad5b99537a2b4df3f6a829e6fac749afbaf921f89c0941/compress_pickle-2.1.0.tar.gz", hash = "sha256:3e944ce0eeab5b6331324d62351c957d41c9327c8417d439843e88fe69b77991", size = 16360 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/4f/f94ac1b84d2169cf2ebf64353ce98fd743f85d30678059c514d9b3d6644c/compress_pickle-2.1.0-py3-none-any.whl", hash = "sha256:598650da4686d9bd97bee185b61e74d7fe1872bb0c23909d5ed2d8793b4a8818", size = 24694 },
+]
+
+[[package]]
+name = "deflate-dict"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/ca5ea149d91d172b9b9d64547b33a87e9613038deb4c8c7bbaf76e26a4be/deflate_dict-1.2.2.tar.gz", hash = "sha256:a51f72562a2056118c6b0915b4ac46a483cc329b43d13d759307e4c027ea20ea", size = 6946 }
+
+[[package]]
 name = "deptry"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -183,6 +217,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/18/95b9776439eac92c98095adb3cbda15588b22b229f9936df30bb10e573ad/deptry-0.23.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5f7e4b1a5232ed6d352fca7173750610a169377d1951d3e9782947191942a765", size = 2004198 },
     { url = "https://files.pythonhosted.org/packages/b2/a9/ea41967d3df7665bab84f1e1e56f7f3a4131ed0a861413a2433bbd9a3c0e/deptry-0.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:04afae204654542406318fd3dd6f4a6697579597f37195437daf84a53ee0ebbf", size = 1607152 },
 ]
+
+[[package]]
+name = "dict-hash"
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deflate-dict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b4/ee7d22a180a56569395b508c98408f5ce6709a9ae74046f9bddd3f5362b6/dict_hash-1.3.6.tar.gz", hash = "sha256:7a59c7d6ce82ea7f00a6f11079e099562f478cc160c3a19d829dbc80fd44d10a", size = 12148 }
 
 [[package]]
 name = "distlib"
@@ -222,6 +265,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+]
+
+[[package]]
+name = "humanize"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/84/ae8e64a6ffe3291105e9688f4e28fa65eba7924e0fe6053d85ca00556385/humanize-4.12.2.tar.gz", hash = "sha256:ce0715740e9caacc982bb89098182cf8ded3552693a433311c6a4ce6f4e12a2c", size = 80871 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/c7/6f89082f619c76165feb633446bd0fee32b0e0cbad00d22480e5aea26ade/humanize-4.12.2-py3-none-any.whl", hash = "sha256:e4e44dced598b7e03487f3b1c6fd5b1146c30ea55a110e71d5d4bca3e094259e", size = 128305 },
 ]
 
 [[package]]
@@ -823,6 +875,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "amazon-orders" },
+    { name = "cache-decorator" },
     { name = "loguru" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -841,6 +894,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "amazon-orders", specifier = ">=3.2.15" },
+    { name = "cache-decorator", specifier = ">=2.2.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.2" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },


### PR DESCRIPTION
Cache the Amazon results since they rarely change and they are the long pole on running frequent tests.

# Design notes
- The `cache_decorator` library recommends not using pickle format due to executable code problems, so that's the reason for the conversions back and forth.  The `date` object was not compatible with plain JSON.
- I chose `10m` duration for the cache as a dumb starting value... could realistically be `6h` or `12h` due to speed of propagation of data to YNAB making the newest transactions relevant.
- The same approach could be applied to YNAB data, but it doesn't run slowly, and I found myself changing YNAB data frequently while testing (e.g. adding `needs memo` payee) so the cache would have caused me problems.
- `CLIParser` is extensible for other args.  `click` and `typer` were other recommended libraries, but were overkill for the trivial needs I started with.

# Security
- Wherever we cache contains detailed info on Amazon transactions.  If it got checked in or pulled off system, that'd be non-ideal.  I used `tempfile`'s temporary directory as a base to force it to stay somewhere outside the project so it didn't get `git commit`ted.  More secure methods probably exist. Path should work fine on all OS's thanks to `os.path.join`

# Usage Notes
- This prints useful helper output:
```
python main.py --help
```

```
usage: main.py [-h] [--force-refresh-amazon | --no-force-refresh-amazon]

options:
  -h, --help            show this help message and exit
  --force-refresh-amazon, --no-force-refresh-amazon
                        Refreshes transactions directly from Amazon instead of using a recently cached version
```