### PR TITLE
Add basic validate_ynamazon Github Actions file, just enforcing ruff so far

### DIFF
--- a/.github/workflows/validate_ynamazon.yml
+++ b/.github/workflows/validate_ynamazon.yml
@@ -1,0 +1,28 @@
+name: YNAmazon
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libjpeg-dev (used for Pillow library)
+        run: sudo apt-get install libjpeg-dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 0.6.12 
+
+      - name: Install Python using uv
+        run: uv python install
+
+      - name: Install Packages using uv
+        run: uv sync
+
+      - name: Run ruff
+        run: uv run ruff check


### PR DESCRIPTION
Add Github Actions to run `ruff`

In order for this to actually protect the repo, the branch protections are needed:

https://github.com/DanielKarp/YNAmazon/settings/rules/new?target=branch

![image](https://github.com/user-attachments/assets/f5ac2653-4831-4c57-88a6-d40b6daa1164) (and the appropriate suboptions below)