### PR TITLE
make raw `yna` call redirect to `yna ynamazon` but without the option to add command-line args

### DIFF
--- a/src/ynamazon/cli.py
+++ b/src/ynamazon/cli.py
@@ -1,4 +1,5 @@
 # ruff: noqa: D212, D415
+import sys
 from typing import Annotated
 
 from rich.console import Console
@@ -168,3 +169,14 @@ def ynamazon(
         ynab_config=Configuration(access_token=ynab_api_key),
         budget_id=ynab_budget_id,
     )
+
+
+@cli.callback(invoke_without_command=True)
+def yna_callback() -> None:
+    if len(sys.argv) == 1:
+        ynamazon(
+            ynab_api_key=settings.ynab_api_key.get_secret_value(),
+            ynab_budget_id=settings.ynab_budget_id.get_secret_value(),
+            amazon_user=settings.amazon_user,
+            amazon_password=settings.amazon_password.get_secret_value(),
+        )  # run with .arg values only, if you need to pass in other values, use `yna ynamazon [args]` instead

--- a/src/ynamazon/cli.py
+++ b/src/ynamazon/cli.py
@@ -1,11 +1,13 @@
 # ruff: noqa: D212, D415
-import sys
 from typing import Annotated
 
 from rich.console import Console
 from rich.table import Table
 from typer import Argument, Option, Typer
 from ynab import Configuration
+from typer import Context
+from typer import run as typer_run
+from rich import print as rprint
 
 from .amazon_transactions import AmazonConfig, get_amazon_transactions
 from .main import process_transactions
@@ -172,11 +174,12 @@ def ynamazon(
 
 
 @cli.callback(invoke_without_command=True)
-def yna_callback() -> None:
-    if len(sys.argv) == 1:
-        ynamazon(
-            ynab_api_key=settings.ynab_api_key.get_secret_value(),
-            ynab_budget_id=settings.ynab_budget_id.get_secret_value(),
-            amazon_user=settings.amazon_user,
-            amazon_password=settings.amazon_password.get_secret_value(),
-        )  # run with .arg values only, if you need to pass in other values, use `yna ynamazon [args]` instead
+def yna_callback(ctx: Context) -> None:
+    """
+    [bold cyan]Run 'yna' to match and update transactions using the arguements in .env. [/]
+
+    [yellow i]Use 'yna ynamazon [ARGS]' to use command-line arguements to override .env. [/]
+    """
+    rprint("[bold cyan]Starting YNAmazon processing...[/]")
+    if ctx.invoked_subcommand is None:
+        typer_run(function=ynamazon)


### PR DESCRIPTION
The reason for not allowing command line args is that it is very hard to do within Typer, as the callback is run every time and it gets messy to figure out if you are running a subcommand or the base command but with args. The apprach I took is to just use a check for the length of `sys.argv` to check if `yna` is being run without any other arguements, and in that case calling `ynamazon` with the function arguements retrieved from settings directly. Users wanting to use command line args would continue to call `yna ynamazon [args]`