### PR TITLE
Cj/cache amazon results 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic-core>=2.33.1",
     "furl>=2.1.4",
     "requests>=2.30.0",
+    "cache-decorator>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ynamazon/amazon_transactions.py
+++ b/src/ynamazon/amazon_transactions.py
@@ -84,7 +84,7 @@ class AmazonTransactionRetriever:
         force_refresh_amazon: bool = False
     ):
         """Initialize an AmazonTransactionRetriever.
-        
+
         amazon_config (AmazonConfig): Configuration for Amazon, primarily credentials
         order_years (list[int] | None): A list of years to fetch transactions for. `None` for the current year.
         transaction_days (int): Number of days to fetch transactions for. Defaults to 31.
@@ -94,7 +94,7 @@ class AmazonTransactionRetriever:
         self.order_years = self.__class__._normalized_years(order_years)
         self.transaction_days = transaction_days
         self.force_refresh_amazon = force_refresh_amazon
-        
+
         # for memoizing the results of method calls
         self._memo = {}
 

--- a/src/ynamazon/amazon_transactions.py
+++ b/src/ynamazon/amazon_transactions.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 from datetime import date
 from decimal import Decimal
 from typing import Annotated, Union  # ,  Self  # not available python <3.11
@@ -7,6 +10,7 @@ from amazonorders.entity.transaction import Transaction
 from amazonorders.orders import AmazonOrders
 from amazonorders.session import AmazonSession
 from amazonorders.transactions import AmazonTransactions
+from cache_decorator import Cache
 from loguru import logger
 from pydantic import AnyUrl, BaseModel, EmailStr, Field, SecretStr, field_validator
 from rich import print as rprint
@@ -72,6 +76,11 @@ class AmazonConfig(BaseModel):
         )
 
 
+@Cache(
+    validity_duration="10m",
+    enable_cache_arg_name="use_cache",
+    cache_path=os.path.join(tempfile.gettempdir(), "ynamazon", "amazon_transactions_json_compatible_amazon_transactions_{_hash}.pkl")
+)
 def get_amazon_transactions(
     order_years: Union[list[int], None] = None,
     transaction_days: int = 31,

--- a/src/ynamazon/cli/cli.py
+++ b/src/ynamazon/cli/cli.py
@@ -9,7 +9,7 @@ from typer import Context
 from typer import run as typer_run
 from rich import print as rprint
 
-from ynamazon.amazon_transactions import AmazonConfig, get_amazon_transactions
+from ynamazon.amazon_transactions import AmazonConfig, AmazonTransactionRetriever
 from ynamazon.main import process_transactions
 from ynamazon.settings import settings
 from ynamazon.ynab_transactions import get_ynab_transactions
@@ -72,6 +72,7 @@ def print_ynab_transactions(
 
 @cli.command("print-amazon")
 def print_amazon_transactions(
+    ctx: Context,
     user_email: Annotated[
         str,
         Argument(help="Amazon username", default_factory=lambda: settings.amazon_user),
@@ -84,7 +85,7 @@ def print_amazon_transactions(
         ),
     ],
     order_years: Annotated[
-        list[int] | None,
+        list[str] | None,
         Option("-y", "--years", help="Order years; leave empty for current year"),
     ] = None,
     transaction_days: Annotated[
@@ -98,13 +99,14 @@ def print_amazon_transactions(
     """
     console = Console()
 
-    config = AmazonConfig(username=user_email, password=user_password)  # type: ignore[arg-type]
+    amazon_config = AmazonConfig(username=user_email, password=user_password) # type: ignore[arg-type]
 
-    transactions = get_amazon_transactions(
-        configuration=config,
+    transactions = AmazonTransactionRetriever(
+        amazon_config=amazon_config,
         order_years=order_years,
         transaction_days=transaction_days,
-    )
+        force_refresh_amazon=ctx.obj["force_refresh_amazon"]
+    ).get_amazon_transactions()
 
     console.print(f"[bold green]Found {len(transactions)} transactions.[/]")
 
@@ -135,6 +137,7 @@ def print_amazon_transactions(
 
 @cli.command()
 def ynamazon(
+    ctx: Context,
     ynab_api_key: Annotated[
         str | None,
         Argument(
@@ -163,26 +166,50 @@ def ynamazon(
             default_factory=lambda: settings.amazon_password.get_secret_value(),
         ),
     ],
+    force_refresh_amazon: Annotated[
+        bool,
+        Option(
+            "--force-refresh-amazon",
+            help="Force refresh of Amazon transactions instead of depending on cached data",
+            is_flag=True,
+        ),
+    ] = False,
 ) -> None:
     """
-    [bold cyan]Match YNAB transactions to Amazon Transactions and optionally update YNAB Memos.[/]
+    [bold cyan](Default) Match YNAB transactions to Amazon Transactions and optionally update YNAB Memos.[/]
 
     [yellow i]All required arguments will use defaults in .env file if not provided.[/]
     """
+    # Store the flag in the Typer context for use in commands
+    ctx.obj = {"force_refresh_amazon": force_refresh_amazon}
+
     process_transactions(
-        amazon_config=AmazonConfig(username=amazon_user, password=amazon_password),  # type: ignore[arg-type]
+        amazon_config=AmazonConfig(username=amazon_user, password=amazon_password, force_refresh_amazon=ctx.obj["force_refresh_amazon"]),  # type: ignore[arg-type]
         ynab_config=Configuration(access_token=ynab_api_key),
         budget_id=ynab_budget_id,
     )
 
 
 @cli.callback(invoke_without_command=True)
-def yna_callback(ctx: Context) -> None:
+def yna_callback(
+    ctx: Context,
+    force_refresh_amazon: Annotated[
+        bool,
+        Option(
+            "--force-refresh-amazon",
+            help="Force refresh of Amazon transactions (don't use the cached data)",
+            is_flag=True,
+        ),
+    ] = False,
+) -> None:
     """
     [bold cyan]Run 'yna' to match and update transactions using the arguements in .env. [/]
 
     [yellow i]Use 'yna ynamazon [ARGS]' to use command-line arguements to override .env. [/]
     """
+    # Store the flag in the Typer context for use in commands
+    ctx.obj = {"force_refresh_amazon": force_refresh_amazon}
+    
     rprint("[bold cyan]Starting YNAmazon processing...[/]")
     if ctx.invoked_subcommand is None:
         typer_run(function=ynamazon)

--- a/src/ynamazon/cli/cli.py
+++ b/src/ynamazon/cli/cli.py
@@ -209,7 +209,7 @@ def yna_callback(
     """
     # Store the flag in the Typer context for use in commands
     ctx.obj = {"force_refresh_amazon": force_refresh_amazon}
-    
+
     rprint("[bold cyan]Starting YNAmazon processing...[/]")
     if ctx.invoked_subcommand is None:
         typer_run(function=ynamazon)

--- a/src/ynamazon/main.py
+++ b/src/ynamazon/main.py
@@ -19,7 +19,10 @@ from ynamazon.ynab_transactions import (
     markdown_formatted_title,
     update_ynab_transaction,
 )
-from ynamazon.ynab_memo import process_memo
+try:
+    from ynamazon.ynab_memo import process_memo
+except ImportError:
+    pass
 
 if TYPE_CHECKING:
     from ynab import Configuration
@@ -102,16 +105,17 @@ def process_transactions(  # noqa: C901
 
         memo.append(
             markdown_formatted_link(
-                f"Order #{amazon_tran.order_number}", amazon_tran.order_link
+                f"\nOrder #{amazon_tran.order_number}", amazon_tran.order_link
             )
         )
 
         console.print("[bold u green]Memo:[/]")
         console.print(str(memo))
         
-        # Process the memo and use new AI summary or trucation if needed
-        memo = process_memo(str(memo))
-        
+        # Only use the AI processing if OpenAI is installed
+        if 'process_memo' in globals():
+            memo = process_memo(str(memo))
+ 
         console.print("[bold u green]Processed Memo:[/]")
         console.print(memo)
 

--- a/src/ynamazon/main.py
+++ b/src/ynamazon/main.py
@@ -116,11 +116,11 @@ def process_transactions(  # noqa: C901
 
         console.print("[bold u green]Memo:[/]")
         console.print(str(memo))
-        
+
         # Only use the AI processing if OpenAI is installed
         if 'process_memo' in globals():
             memo = process_memo(str(memo))
- 
+
         console.print("[bold u green]Processed Memo:[/]")
         console.print(memo)
 

--- a/src/ynamazon/main.py
+++ b/src/ynamazon/main.py
@@ -7,7 +7,7 @@ from rich.prompt import Confirm
 
 from ynamazon.amazon_transactions import (
     AmazonConfig,
-    get_amazon_transactions,
+    AmazonTransactionRetriever,
     locate_amazon_transaction_by_amount,
 )
 from ynamazon.exceptions import YnabSetupError
@@ -47,6 +47,7 @@ def process_transactions(  # noqa: C901
     amazon_config: AmazonConfig | None = None,
     ynab_config: "Configuration | None" = None,
     budget_id: str | None = None,
+    force_refresh_amazon: bool = False
 ) -> None:
     """Match YNAB transactions to Amazon Transactions and optionally update YNAB Memos."""
     amazon_config = amazon_config or AmazonConfig()
@@ -64,7 +65,11 @@ def process_transactions(  # noqa: C901
         return
 
     console.print("[cyan]Starting search for Amazon transactions...[/]")
-    amazon_trans = get_amazon_transactions()
+    amazon_trans = AmazonTransactionRetriever(
+        amazon_config=amazon_config,
+        force_refresh_amazon=force_refresh_amazon
+    ).get_amazon_transactions()
+
     console.print(
         f"[green]{len(amazon_trans)} Amazon transactions retrieved successfully.[/]"
     )

--- a/src/ynamazon/settings.py
+++ b/src/ynamazon/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     """Settings configuration for project."""
 
     model_config = SettingsConfigDict(
-        env_file=".env", 
+        env_file=".env",
         env_file_encoding="utf-8",
         env_prefix="",
         case_sensitive=True,

--- a/src/ynamazon/ynab_memo.py
+++ b/src/ynamazon/ynab_memo.py
@@ -7,8 +7,8 @@ from openai import OpenAI
 from openai import AuthenticationError, RateLimitError, APIError
 from ynamazon.settings import settings
 from ynamazon.prompts import (
-    AMAZON_SUMMARY_SYSTEM_PROMPT, 
-    AMAZON_SUMMARY_PLAIN_PROMPT, 
+    AMAZON_SUMMARY_SYSTEM_PROMPT,
+    AMAZON_SUMMARY_PLAIN_PROMPT,
     AMAZON_SUMMARY_MARKDOWN_PROMPT
 )
 from .exceptions import MissingOpenAIAPIKey, InvalidOpenAIAPIKey, OpenAIEmptyResponseError
@@ -25,17 +25,17 @@ def generate_ai_summary(
     max_length: int = YNAB_MEMO_LIMIT
 ) -> str | None:
     """Uses OpenAI to generate a concise human-readable memo that fits within the character limit.
-    
+
     Args:
         items: List of item descriptions
         order_url: Amazon order URL
         order_total: Total order amount (if different from transaction)
         transaction_amount: Current transaction amount
         max_length: Maximum allowed characters (default: YNAB_MEMO_LIMIT)
-    
+
     Returns:
         A human-readable memo summarized by AI
-        
+
     Raises:
         MissingOpenAIAPIKey: If OpenAI API key is not found
         InvalidOpenAIAPIKey: If OpenAI API key is invalid or authentication fails
@@ -45,24 +45,24 @@ def generate_ai_summary(
     # Check if OpenAI key is available
     if settings.openai_api_key is None or not settings.openai_api_key.get_secret_value():
         raise MissingOpenAIAPIKey("OpenAI API key not found")
-    
+
     # Create client
     client = OpenAI(api_key=settings.openai_api_key.get_secret_value())
-    
+
     # Prepare content for summarization
     partial_order_note = ""
     if order_total and transaction_amount and order_total != transaction_amount:
         partial_order_note = (f"-This transaction doesn't represent the entire order. The order total is ${order_total}-")
-    
+
     # Format items as text for the prompt
     items_text = "\n".join([f"- {item}" for item in items])
-    
+
     # Select the appropriate prompt based on markdown setting
     user_prompt = AMAZON_SUMMARY_MARKDOWN_PROMPT if settings.ynab_use_markdown else AMAZON_SUMMARY_PLAIN_PROMPT
-    
+
     # Add the items to the prompt
     full_prompt = f"{user_prompt}\n\nOrder Details:\n{items_text}"
-    
+
     try:
         # Get the response from OpenAI
         response = client.chat.completions.create(
@@ -83,7 +83,7 @@ def generate_ai_summary(
     except Exception as e:
         logger.error(f"Unexpected error using OpenAI API: {e}")
         return None
-        
+
     # Check for empty response
     if not response.choices or not response.choices[0].message.content:
         raise OpenAIEmptyResponseError("OpenAI returned an empty response")
@@ -108,7 +108,7 @@ def normalize_memo(memo: str) -> str:
     result = []
     current_line = ""
     in_url = False
-    
+
     for line in lines:
         stripped = line.strip()
         if "amazon.com" in line:
@@ -129,10 +129,10 @@ def normalize_memo(memo: str) -> str:
                 result.append(current_line)
                 current_line = ""
             result.append(line)
-    
+
     if current_line:
         result.append(current_line)
-    
+
     return "\n".join(result)
 
 
@@ -140,32 +140,32 @@ def extract_order_url(memo: str) -> str:
     """Extract the Amazon order URL from a memo, handling both markdown and non-markdown formats."""
     # First normalize the memo to handle split lines
     normalized_memo = normalize_memo(memo)
-    
+
     # First try to find a markdown URL
     markdown_url_match = re.search(r'\[Order\s*#[\w-]+\]\((https://www\.amazon\.com/gp/your-account/order-details\?orderID=[\w-]+)\)', normalized_memo)
     if markdown_url_match:
         return markdown_url_match.group(1)
-    
+
     # If no markdown URL found, look for a plain URL
     plain_url_match = re.search(r'https://www\.amazon\.com/gp/your-account/order-details\?orderID=[\w-]+', normalized_memo)
     if plain_url_match:
         return plain_url_match.group(0)
-    
+
     return None
 
 
 def _extract_memo_parts(memo: str) -> tuple[str | None, str | None, list[str]]:
     """Extract key parts from the memo: multi-order line, items header, and item lines."""
     lines = [line.strip() for line in memo.replace("\r\n", "\n").split("\n") if line.strip()]
-    
+
     multi_order_line = next((line for line in lines if line.startswith("-This transaction")), None)
     items_header = next((line for line in lines if line == "Items"), None)
-    
+
     item_lines = []
     for line in lines:
         if line[0].isdigit() and ". " in line:
             item_lines.append(line)
-    
+
     return multi_order_line, items_header, item_lines
 
 
@@ -180,7 +180,7 @@ def _truncate_item_lines(item_lines: list[str], available_space: int) -> list[st
     """Truncate item lines to fit within available space."""
     truncated_items = []
     current_length = 0
-    
+
     for item in item_lines:
         item_length = len(item) + 1  # +1 for newline
         if current_length + item_length <= available_space:
@@ -191,7 +191,7 @@ def _truncate_item_lines(item_lines: list[str], available_space: int) -> list[st
             if remaining_space >= 4:  # Enough space for "..."
                 truncated_items.append("...")
             break
-    
+
     return truncated_items
 
 
@@ -202,20 +202,20 @@ def truncate_memo(memo: str) -> str:
 
     # Extract the URL first
     url_line = extract_order_url(memo)
-    
+
     # Strip all markdown formatting
     clean_memo = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', memo)  # Remove markdown links
     clean_memo = re.sub(r'\*\*([^*]+)\*\*', r'\1', clean_memo)  # Remove bold
-    
+
     # Extract key parts
     multi_order_line, items_header, item_lines = _extract_memo_parts(clean_memo)
-    
+
     # Calculate available space
     available_space = _calculate_remaining_space(multi_order_line, items_header, item_lines, url_line)
-    
+
     # Truncate items if needed
     truncated_items = _truncate_item_lines(item_lines, available_space)
-    
+
     # Build final memo
     final_lines = []
     if multi_order_line:
@@ -224,7 +224,7 @@ def truncate_memo(memo: str) -> str:
         final_lines.append(items_header)
     final_lines.extend(truncated_items)
     final_lines.append(url_line)
-    
+
     return "\n".join(final_lines)
 
 
@@ -273,34 +273,34 @@ def summarize_memo_with_ai(memo: str, order_url: str) -> str:
 
 def process_memo(memo: str) -> str:
     """Process a memo using AI summarization if enabled, otherwise use truncation if needed.
-    
+
     This function handles both markdown and non-markdown memos based on the settings.ynab_use_markdown setting:
     - If markdown is enabled, it preserves markdown formatting in the output
     - If markdown is disabled, it strips all markdown formatting
-    
+
     The processing strategy is:
     1. If AI summarization is enabled (settings.use_ai_summarization):
        - Uses OpenAI to generate a concise summary
        - Preserves markdown formatting if enabled
        - Ensures the summary fits within YNAB's character limit
-    
+
     2. If AI summarization is disabled:
        - Checks if memo exceeds YNAB's character limit
        - If it does, uses truncation to shorten while preserving important information
        - If not, returns the original memo
-    
+
     Returns:
         str: The processed memo, either AI-summarized or truncated, with appropriate markdown formatting
     """
     original_memo = str(memo)
     original_length = len(original_memo)
-    
+
     # Extract order URL first since we'll need it for both paths
     order_url = extract_order_url(original_memo)
     if not order_url:
         logger.warning("No Amazon order URL found in memo")
         return original_memo
-    
+
     if settings.use_ai_summarization:
         logger.info("Using AI summarization")
         processed_memo = summarize_memo_with_ai(original_memo, order_url)
@@ -309,31 +309,31 @@ def process_memo(memo: str) -> str:
             return processed_memo
         else:
             logger.warning("AI summarization failed, falling back to truncation")
-    
+
     # If AI summarization is disabled or failed, check if we need truncation
     if original_length > YNAB_MEMO_LIMIT:
         processed_memo = truncate_memo(original_memo)
         logger.info(f"Processed memo from {original_length} to {len(processed_memo)} characters using truncation")
         return processed_memo
-    
+
     return original_memo
 
 
 def summarize_memo(memo: str) -> str:
     """Summarize a memo using AI if enabled, otherwise use truncation."""
     original_memo = str(memo)
-    
+
     # Extract order URL first since we'll need it for both paths
     order_url = extract_order_url(original_memo)
     if not order_url:
         logger.warning("No Amazon order URL found in memo")
         return truncate_memo(original_memo)
-    
+
     if settings.use_ai_summarization:
         processed_memo = summarize_memo_with_ai(original_memo, order_url)
         if processed_memo:
             return processed_memo
         else:
             logger.warning("AI summarization failed, falling back to truncation")
-    
-    return truncate_memo(original_memo) 
+
+    return truncate_memo(original_memo)

--- a/src/ynamazon/ynab_transactions.py
+++ b/src/ynamazon/ynab_transactions.py
@@ -163,35 +163,35 @@ def update_ynab_transaction(
     data = PutTransactionWrapper(
         transaction=ExistingTransaction.model_validate(transaction.to_dict())
     )
-    
+
     # Convert memo to string if it's a MultiLineText object
     memo_str = str(memo)
-    
+
     # Ensure memo doesn't exceed 500 character limit
     if len(memo_str) > 500:
         logger.warning(f"Memo exceeds 500 character limit ({len(memo_str)} chars). Truncating...")
         # Keep the important parts - first warning line, and the URL at the end
         lines = memo_str.split('\n')
-        
+
         # Extract the URL at the end (it must be preserved)
         url_line = lines[-1]
-        
+
         # Keep the warning header if it exists
         header = ""
         if len(lines) > 0 and '-This transaction doesn' in lines[0]:
             header = lines[0] + '\n\n'
-        
+
         # Calculate remaining space for content
         remaining_space = 500 - len(header) - len(url_line) - 4  # 4 chars for "...\n"
-        
+
         # Get middle content (item list) and truncate if needed
         middle_content = '\n'.join(lines[1:-1])
         if len(middle_content) > remaining_space:
             middle_content = middle_content[:remaining_space] + "..."
-        
+
         # Combine the parts to stay under 500 chars
         memo_str = f"{header}{middle_content}\n{url_line}"
-    
+
     data.transaction.memo = memo_str
     data.transaction.payee_id = payee_id
     with ApiClient(configuration=configuration) as api_client:

--- a/uv.lock
+++ b/uv.lock
@@ -70,6 +70,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cache-decorator"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "compress-json" },
+    { name = "compress-pickle" },
+    { name = "deflate-dict" },
+    { name = "dict-hash" },
+    { name = "humanize" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/52/b372ebef6d7e8322dd46ff176fa91cb8374adee85ec54fd6b13bbe0a8eaf/cache_decorator-2.2.0.tar.gz", hash = "sha256:ebb427b5acb00fb0a47ed9fc7d52fe96de94f40ca52f381205ace8756df6df5a", size = 35875 }
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -170,6 +183,21 @@ wheels = [
 ]
 
 [[package]]
+name = "compress-json"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/e5/3974ae0348691434795902f587e33b2e0cb10fdd66a649ca32edabcc4fcb/compress_json-1.1.1.tar.gz", hash = "sha256:2d9aea3fabfe3b9a77d2a8afa005c47a6b3b3fb59d6eb833ec3337f99fba3164", size = 6629 }
+
+[[package]]
+name = "compress-pickle"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/23/a448abd4e98b64ad5b99537a2b4df3f6a829e6fac749afbaf921f89c0941/compress_pickle-2.1.0.tar.gz", hash = "sha256:3e944ce0eeab5b6331324d62351c957d41c9327c8417d439843e88fe69b77991", size = 16360 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/4f/f94ac1b84d2169cf2ebf64353ce98fd743f85d30678059c514d9b3d6644c/compress_pickle-2.1.0-py3-none-any.whl", hash = "sha256:598650da4686d9bd97bee185b61e74d7fe1872bb0c23909d5ed2d8793b4a8818", size = 24694 },
+]
+
+[[package]]
 name = "coverage"
 version = "7.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +253,12 @@ toml = [
 ]
 
 [[package]]
+name = "deflate-dict"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/ca5ea149d91d172b9b9d64547b33a87e9613038deb4c8c7bbaf76e26a4be/deflate_dict-1.2.2.tar.gz", hash = "sha256:a51f72562a2056118c6b0915b4ac46a483cc329b43d13d759307e4c027ea20ea", size = 6946 }
+
+[[package]]
 name = "deptry"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -253,6 +287,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/18/95b9776439eac92c98095adb3cbda15588b22b229f9936df30bb10e573ad/deptry-0.23.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5f7e4b1a5232ed6d352fca7173750610a169377d1951d3e9782947191942a765", size = 2004198 },
     { url = "https://files.pythonhosted.org/packages/b2/a9/ea41967d3df7665bab84f1e1e56f7f3a4131ed0a861413a2433bbd9a3c0e/deptry-0.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:04afae204654542406318fd3dd6f4a6697579597f37195437daf84a53ee0ebbf", size = 1607152 },
 ]
+
+[[package]]
+name = "dict-hash"
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deflate-dict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b4/ee7d22a180a56569395b508c98408f5ce6709a9ae74046f9bddd3f5362b6/dict_hash-1.3.6.tar.gz", hash = "sha256:7a59c7d6ce82ea7f00a6f11079e099562f478cc160c3a19d829dbc80fd44d10a", size = 12148 }
 
 [[package]]
 name = "distlib"
@@ -372,6 +415,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "humanize"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/84/ae8e64a6ffe3291105e9688f4e28fa65eba7924e0fe6053d85ca00556385/humanize-4.12.2.tar.gz", hash = "sha256:ce0715740e9caacc982bb89098182cf8ded3552693a433311c6a4ce6f4e12a2c", size = 80871 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/c7/6f89082f619c76165feb633446bd0fee32b0e0cbad00d22480e5aea26ade/humanize-4.12.2-py3-none-any.whl", hash = "sha256:e4e44dced598b7e03487f3b1c6fd5b1146c30ea55a110e71d5d4bca3e094259e", size = 128305 },
 ]
 
 [[package]]
@@ -1209,6 +1261,7 @@ name = "ynamazon"
 source = { editable = "." }
 dependencies = [
     { name = "amazon-orders" },
+    { name = "cache-decorator" },
     { name = "furl" },
     { name = "loguru" },
     { name = "pydantic", extra = ["email"] },
@@ -1244,6 +1297,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "amazon-orders", specifier = ">=3.2.15" },
+    { name = "cache-decorator", specifier = ">=2.2.0" },
     { name = "furl", specifier = ">=2.1.4" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", marker = "extra == 'ai'", specifier = ">=1.12.0" },


### PR DESCRIPTION
Update of #14 based on latest code.  Thanks for your patience in getting the time to do this update.

Key change from last time is moving to `pkl` format - less secure since objects are created from the cache.  Objects being returned from Amazon fetch are more complicated now, so this made sense.

Also made mainline app load not fail if OpenAI was missing since it's optional.